### PR TITLE
Unicode math characters cause LaTeX errors.

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -7,6 +7,7 @@
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \usepackage[mathletters]{ucs}
   \usepackage[utf8]{inputenc}
 $if(euro)$
   \usepackage{eurosym}


### PR DESCRIPTION
This is a one-line patch just to fix a problem I discovered when putting
Unicode characters in Markdown files and generating LaTeX output.