### PR TITLE
Add $institute to the latex template

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -138,6 +138,9 @@ $endif$
 $if(author)$
 \author{$for(author)$$author$$sep$ \and $endfor$}
 $endif$
+$if(institute)$
+\institute{$for(institute)$$institute$$sep$ \and $endfor$}
+$endif$
 \date{$date$}
 $for(header-includes)$
 $header-includes$


### PR DESCRIPTION
Adding the $institute variable allows me to use pandoc for writing
papers using the llncs document class.

http://www.springer.com/computer/lncs/lncs+authors?SGWID=0-40209-0-0-0