### PR TITLE
Fix revealjs theme functionality

### DIFF
--- a/default.revealjs
+++ b/default.revealjs
@@ -27,6 +27,11 @@ $endfor$
 $else$
     <link rel="stylesheet" href="$revealjs-url$/css/theme/simple.css" id="theme">
 $endif$
+$if(theme)$
+    <link rel="stylesheet" href="$revealjs-url$/css/theme/$theme$.css" id="theme">
+$else$
+    <link rel="stylesheet" href="$revealjs-url$/css/theme/black.css" id="theme">
+$endif$
     <!-- If the query includes 'print-pdf', include the PDF print sheet -->
     <script>
       if( window.location.search.match( /print-pdf/gi ) ) {


### PR DESCRIPTION
Use up-to-date theme as link convention for revealjs. Leave old theme as
config option just in case. Match current revealjs behavior of
defaulting to "black" theme.

Fixes #80

Signed-off-by: Aaron Browne <aaron0browne@gmail.com>