### PR TITLE
Added short{author,title,subtitle,date} for beamer

### DIFF
--- a/default.beamer
+++ b/default.beamer
@@ -122,15 +122,15 @@ $header-includes$
 $endfor$
 
 $if(title)$
-\title{$title$}
+\title$if(shorttitle)$[$shorttitle$]$endif${$title$}
 $endif$
 $if(subtitle)$
-\subtitle{$subtitle$}
+\subtitle$if(shortsubtitle)$[$shortsubtitle$]$endif${$subtitle$}
 $endif$
 $if(author)$
-\author{$for(author)$$author$$sep$ \and $endfor$}
+\author$if(shortauthor)$[$shortauthor$]$endif${$for(author)$$author$$sep$ \and $endfor$}
 $endif$
-\date{$date$}
+\date$if(shortdate)$[$shortdate$]$endif${$date$}
 
 \begin{document}
 $if(title)$


### PR DESCRIPTION
This was already [discussed on the mailing list some years ago](https://groups.google.com/forum/#!topic/pandoc-discuss/XMYG6ewG7a0), my patch extends this a little bit and is adjusted for the support of multiple authors, which was added since then.

Lots of beamer templates offer support for using following additional variables:

- `shorttitle`
- `shortsubtitle`
- `shortauthor`
- `shortdate`

These are set by passing them as option to their respective "long" counterparts, and used by eg `\insertshortauthor`, mostly within frame headers and footers. An example use case would be to include contact data or a bunch of authors within the title page, but remove those form the headline.

An example YAML metadata block:

    ---
    title: An Rather Long Example Title
    shorttitle: Example Title
    author:
    - | 
        Jens Erat  
        \vspace{0.5cm}
        \scriptsize
        email@jenserat.de  
    shortauthor: Jens Erat
    ---

The patch will neither break output for other templates nor beamer when the short variables are not included. If they would be helpful for other templates (and knowingly do not break anything in them), I'd be glad to provide a similar patch for them as well.