### PR TITLE
Move include-before to top of document

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -144,6 +144,11 @@ $header-includes$
 $endfor$
 
 \begin{document}
+
+$for(include-before)$
+$include-before$
+$endfor$
+
 $if(title)$
 \maketitle
 $endif$
@@ -153,10 +158,6 @@ $abstract$
 \end{abstract}
 $endif$
 
-$for(include-before)$
-$include-before$
-
-$endfor$
 $if(toc)$
 {
 \hypersetup{linkcolor=black}


### PR DESCRIPTION
When processing through XeLaTeX, font selections need to come before the title or the title will be displayed in the default font.