### PR TITLE
Beamer: Improve compatibility with third-party templates

### DIFF
--- a/default.beamer
+++ b/default.beamer
@@ -1,6 +1,6 @@
-\documentclass[$if(fontsize)$$fontsize$,$endif$$if(handout)$handout,$endif$$if(beamer)$ignorenonframetext,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
+\documentclass[$if(fontsize)$$fontsize$,$endif$$if(handout)$handout,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
 $if(theme)$
-\usetheme{$theme$}
+\usetheme$if(themeopts)$[$themeopts$]$endif${$theme$}
 $endif$
 $if(colortheme)$
 \usecolortheme{$colortheme$}
@@ -14,7 +14,9 @@ $endif$
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
 \usepackage{fixltx2e} % provides \textsubscript
-\usepackage{lmodern}
+$if(font)$
+\usepackage{$font$}
+$endif$
 \ifxetex
   \usepackage{fontspec,xltxtra,xunicode}
   \defaultfontfeatures{Mapping=tex-text,Scale=MatchLowercase}
@@ -131,10 +133,13 @@ $if(author)$
 \author{$for(author)$$author$$sep$ \and $endfor$}
 $endif$
 \date{$date$}
+$if(institute)$
+\institute{$institute$}
+$endif$
 
 \begin{document}
 $if(title)$
-\frame{\titlepage}
+\maketitle
 $endif$
 
 $for(include-before)$

--- a/default.beamer
+++ b/default.beamer
@@ -117,7 +117,12 @@ $if(verbatim-in-note)$
 \VerbatimFootnotes % allows verbatim text in footnotes
 $endif$
 $if(lang)$
-\usepackage[$lang$]{babel}
+\ifxetex
+  \usepackage{polyglossia}
+  \setdefaultlanguage[$if(spelling)$spelling=$spelling$$endif$,babelshorthands=true]{$lang$}
+\else
+  \usepackage[$lang$]{babel}
+\fi
 $endif$
 $for(header-includes)$
 $header-includes$

--- a/default.beamer
+++ b/default.beamer
@@ -18,7 +18,7 @@ $if(font)$
 \usepackage{$font$}
 $endif$
 \ifxetex
-  \usepackage{fontspec,xltxtra,xunicode}
+  \usepackage{fontspec,xunicode}
   \defaultfontfeatures{Mapping=tex-text,Scale=MatchLowercase}
   \newcommand{\euro}{€}
 \else

--- a/default.beamer
+++ b/default.beamer
@@ -83,8 +83,9 @@ $if(graphics)$
 \setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
 $endif$
 
-% Comment these out if you don't want a slide with just the
+% Set `section-titles` if you don't want a slide with just the
 % part/section/subsection/subsubsection title:
+$if(section-titles)$
 \AtBeginPart{
   \let\insertpartnumber\relax
   \let\partname\relax
@@ -100,6 +101,7 @@ $endif$
   \let\subsectionname\relax
   \frame{\subsectionpage}
 }
+$endif$
 
 $if(strikeout)$
 \usepackage[normalem]{ulem}


### PR DESCRIPTION
- Template font does not get overridden
- Template options can be specified
- Institute can be specified
- Remove ignorenonframetext and use \titlepage to prevent numbering
  of title page

See also https://github.com/matze/mtheme/issues/28