### PR TITLE
Add option for ToC color

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -159,7 +159,7 @@ $include-before$
 $endfor$
 $if(toc)$
 {
-\hypersetup{linkcolor=black}
+\hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$black$endif$}
 \setcounter{tocdepth}{$toc-depth$}
 \tableofcontents
 }


### PR DESCRIPTION
If the link color in the table of contents is a different one from default, it should be customisable. Some may see the default black and not realise that the table is interactive - especially if the viewer sees other parts of the document that could be interactive but are not for that particular build e.g. citations.