### PR TITLE
Redefine (sub)paragraphs in default LaTeX template

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -143,6 +143,12 @@ $for(header-includes)$
 $header-includes$
 $endfor$
 
+% Redefines (sub)paragraphs to behave more like sections
+\let\oldparagraph\paragraph
+\renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
+\let\oldsubparagraph\subparagraph
+\renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
+
 \begin{document}
 $if(title)$
 \maketitle


### PR DESCRIPTION
This should make those behave more like sections, as per https://github.com/jgm/pandoc/issues/1658