### PR TITLE
Fix paragraph undefined problem

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -146,10 +146,14 @@ $header-includes$
 $endfor$
 
 % Redefines (sub)paragraphs to behave more like sections
+\ifx\paragraph\undefined\else
 \let\oldparagraph\paragraph
 \renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
+\fi
+\ifx\subparagraph\undefined\else
 \let\oldsubparagraph\subparagraph
 \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
+\fi
 
 \begin{document}
 $if(title)$


### PR DESCRIPTION
This uses TeX primitives, since using `\@ifundefined` would define `\paragraph` as `\relax` if it's not defined, which could be (a) disruptive and (b) would not report on subsequent errors with `\paragraph`, if it's used anywhere else in the document.