### PR TITLE
Use creator.role instead of creator.type

### DIFF
--- a/default.epub
+++ b/default.epub
@@ -34,7 +34,7 @@ $for(author)$
   <h2 class="author">$author$</h2>
 $endfor$
 $for(creator)$
-  <h2 class="$creator.type$">$creator.text$</h2>
+  <h2 class="$creator.role$">$creator.text$</h2>
 $endfor$
 $if(publisher)$
   <p class="publisher">$publisher$</p>

--- a/default.epub3
+++ b/default.epub3
@@ -39,7 +39,7 @@ $for(author)$
   <h2 class="author">$author$</h2>
 $endfor$
 $for(creator)$
-  <h2 class="$creator.type$">$creator.text$</h2>
+  <h2 class="$creator.role$">$creator.text$</h2>
 $endfor$
 $if(publisher)$
   <p class="publisher">$publisher$</p>


### PR DESCRIPTION
The EPUB metadata description specifies "role" for creators, not "type": 
http://pandoc.org/README.html#epub-metadata

This fixed the two epub templates to use the correct syntax.