### PR TITLE
Support for Asian languages, CJKmainfont label

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -38,6 +38,10 @@ $endif$
 $if(mathfont)$
     \setmathfont(Digits,Latin,Greek){$mathfont$}
 $endif$
+$if(CJKmainfont)$
+    \usepackage{xeCJK}
+    \setCJKmainfont{$CJKmainfont$}
+$endif$
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}


### PR DESCRIPTION
Works only with xelatex.
This is not a big deal since when it hits on a utf8 unknown char (say Asian script), pandoc suggests to switch to the xelatex engine.

This is already changing my life! :dancer: 