### PR TITLE
Pass options to CJKmainfont (CJKoption)

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -40,7 +40,7 @@ $if(mathfont)$
 $endif$
 $if(CJKmainfont)$
     \usepackage{xeCJK}
-    \setCJKmainfont{$CJKmainfont$}
+    \setCJKmainfont[$CJKoption$]{$CJKmainfont$}
 $endif$
 \fi
 % use upquote if available, for straight quotes in verbatim environments

--- a/default.latex
+++ b/default.latex
@@ -40,7 +40,7 @@ $if(mathfont)$
 $endif$
 $if(CJKmainfont)$
     \usepackage{xeCJK}
-    \setCJKmainfont[$CJKoption$]{$CJKmainfont$}
+    \setCJKmainfont[$CJKoptions$]{$CJKmainfont$}
 $endif$
 \fi
 % use upquote if available, for straight quotes in verbatim environments


### PR DESCRIPTION
Follow-up to pull request #99 
It is often good practice to set a slightly bigger font size for Asian characters compared to Latin ones.

Which could be reflected by something like below:
```
mainfont: Linux Libertine
CJKmainfont: Noto Sans S Chinese Light
CJKoption: Scale=1.05
title: Spelling Rules of Pinyin
subtitle: 汉语拼音拼写规则
```