### PR TITLE
ConTeXt template description lists

### DIFF
--- a/default.context
+++ b/default.context
@@ -31,7 +31,7 @@ $endif$
 
 \definedescription
   [description]
-  [headstyle=bold, style=normal, location=hanging, width=broad, margin=1cm]
+  [headstyle=bold, style=normal, location=hanging, width=broad, margin=1cm, alternative=hanging]
 
 \setupitemize[autointro]    % prevent orphan list intro
 \setupitemize[indentnext=no]


### PR DESCRIPTION
ConTeXt template description lists: activate hanging text so if you have description keys that have not the same length, the paragraphs are still aligned and look nice.

Before:
![bad](http://s18.postimg.org/3z1oxvv1l/bad.png)

After:
![good](http://s21.postimg.org/mljka3rvr/good.png)