### PR TITLE
Enable to hide links as plain text (hyperref option)

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -69,8 +69,8 @@ $endif$
             citecolor=$if(citecolor)$$citecolor$$else$blue$endif$,
             urlcolor=$if(urlcolor)$$urlcolor$$else$blue$endif$,
             linkcolor=$if(linkcolor)$$linkcolor$$else$magenta$endif$,
-            $if(hidelinks)$hidelinks=$hidelinks$,$endif$
-            pdfborder={0 0 0}}
+            pdfborder={0 0 0}
+            $if(hidelinks)$,hidelinks,$endif$}
 \urlstyle{same}  % don't use monospace font for urls
 $if(lang)$
 \ifxetex

--- a/default.latex
+++ b/default.latex
@@ -69,6 +69,7 @@ $endif$
             citecolor=$if(citecolor)$$citecolor$$else$blue$endif$,
             urlcolor=$if(urlcolor)$$urlcolor$$else$blue$endif$,
             linkcolor=$if(linkcolor)$$linkcolor$$else$magenta$endif$,
+            $if(hidelinks)$hidelinks=$hidelinks$,$endif$
             pdfborder={0 0 0}}
 \urlstyle{same}  % don't use monospace font for urls
 $if(lang)$


### PR DESCRIPTION
Add a variable "hidelinks" to allow to hide links as plain text in LaTeX. It removes any color and borer. The variable does not need any particular argument  (see https://www.tug.org/applications/hyperref/manual.html)