### PR TITLE
 Deal with conflicts with tufte-handout.cls

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -53,6 +53,8 @@ $endif$
 $if(geometry)$
 \usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
 $endif$
+\makeatletter
+\@ifpackageloaded{hyperref}{}{%
 \ifxetex
   \usepackage[setpagesize=false, % page size defined by xetex
               unicode=false, % unicode breaks when used with xetex
@@ -60,7 +62,13 @@ $endif$
 \else
   \usepackage[unicode=true]{hyperref}
 \fi
+}
+\makeatother
+\makeatletter
+\@ifpackageloaded{color}{}{%
 \usepackage[usenames,dvipsnames]{color}
+}
+\makeatother
 \hypersetup{breaklinks=true,
             bookmarks=true,
             pdfauthor={$author-meta$},

--- a/default.latex
+++ b/default.latex
@@ -63,10 +63,10 @@ $endif$
   \usepackage[unicode=true]{hyperref}
 \fi
 }
-\makeatother
-\makeatletter
-\@ifpackageloaded{color}{}{%
-\usepackage[usenames,dvipsnames]{color}
+\@ifpackageloaded{color}{
+    \PassOptionsToPackage{usenames,dvipsnames}{color}
+}{%
+    \usepackage[usenames,dvipsnames]{color}
 }
 \makeatother
 \hypersetup{breaklinks=true,


### PR DESCRIPTION
There are several conflicts that are raised when you use tufte-handout
layout with the default.latex template, namely `hyperref` and `color`, which
are already loaded by the class.

This commit enables to only load `hyperref` and `color` packages if they
are not already loaded (by tufte-handout).