### PR TITLE
Add support for inner/outer theme

### DIFF
--- a/default.beamer
+++ b/default.beamer
@@ -8,6 +8,12 @@ $endif$
 $if(fonttheme)$
 \usefonttheme{$fonttheme$}
 $endif$
+$if(innertheme)$
+\useinnertheme{$innertheme$}
+$endif$
+$if(outertheme)$
+\useoutertheme{$outertheme$}
+$endif$
 \setbeamertemplate{caption}[numbered]
 \setbeamertemplate{caption label separator}{:}
 \setbeamercolor{caption name}{fg=normal text.fg}


### PR DESCRIPTION
Beamer allows configuring inner and outer themes.

This patch allows pandoc's user to set the expected part of the theme.