### PR TITLE
potential author bug in template, please check

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -161,7 +161,7 @@ $if(title)$
 \title{$title$$if(subtitle)$\\\vspace{0.5em}{\large $subtitle$}$endif$}
 $endif$
 $if(author)$
-\author{$for(author)$$author$$sep$ \and $endfor$}
+\author{$for(author)$$author.name$$sep$ \and $endfor$}
 $endif$
 \date{$date$}
 $for(header-includes)$


### PR DESCRIPTION
Amended the latex template

Was using this yaml metadata to test the template

```
---
title: 'This is the title: it contains a colon'
author:
- name: Author One
  affiliation: University of Somewhere
- name: Author Two
  affiliation: University of Nowhere
tags: [nothing, nothingness]
abstract: |
    This is the abstract.
    It consists of two paragraphs.
...
```

and found that for this template, it just showed "true true", rather than "Author One      Author Two".

I think it's because in

```
$if(author)$
\author{$for(author)$$author$$sep$ \and $endfor$}
$endif$
```

`$author$` should be `$author.name$` like below. Since author is a container of multiple authors

```
$if(author)$
\author{$for(author)$$author.name$$sep$ \and $endfor$}
$endif$
```

Perhaps the reason why this wasn't noticed before, is that it probbly worked for single authors, but failed with multiple authors.