### PR TITLE
Remove xltxtra, xunicode from LaTeX template.

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -20,7 +20,6 @@ $endif$
 \else % if luatex or xelatex
   \ifxetex
     \usepackage{mathspec}
-    \usepackage{xltxtra,xunicode}
   \else
     \usepackage{fontspec}
   \fi


### PR DESCRIPTION
This fixes a problem with complex superscripts/subscripts, by removing use of the `realscripts` package: see wspr/realscripts/issues/6. None of the other features provided by `xltxtra` are necessary to Pandoc. The `fontspec` package already loads `xunicode` (since at least 2010).