### PR TITLE
Update reveal.js template from 3.1 source.

### DIFF
--- a/default.revealjs
+++ b/default.revealjs
@@ -195,6 +195,15 @@ $endif$
 $if(parallaxBackgroundVertical)$
         parallaxBackgroundVertical: '$parallaxBackgroundVertical$',
 $endif$
+$if(width)$
+        // The "normal" size of the presentation, aspect ratio will be preserved
+        // when the presentation is scaled to fit different resolutions. Can be
+        // specified using percentage units.
+        width: $width$,
+$endif$
+$if(height)$
+        height: $height$,
+$endif$
 $if(margin)$
         // Factor of the display size that should remain empty around the content
         margin: $margin$,

--- a/default.revealjs
+++ b/default.revealjs
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
-<html$if(lang)$ lang="$lang$"$endif$>
+<html$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
 <head>
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">
 $for(author-meta)$
-  <meta name="author" content="$author-meta$" />
+  <meta name="author" content="$author-meta$">
 $endfor$
 $if(date-meta)$
-  <meta name="dcterms.date" content="$date-meta$" />
+  <meta name="dcterms.date" content="$date-meta$">
 $endif$
-  <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
   <link rel="stylesheet" href="$revealjs-url$/css/reveal.css"/>
   <style type="text/css">code{white-space: pre;}</style>
 $if(highlighting-css)$
@@ -28,15 +28,13 @@ $endif$
 $for(css)$
   <link rel="stylesheet" href="$css$"/>
 $endfor$
-  <!-- If the query includes 'print-pdf', include the PDF print sheet -->
+  <!-- Printing and PDF exports -->
   <script>
-    if( window.location.search.match( /print-pdf/gi ) ) {
-      var link = document.createElement( 'link' );
-      link.rel = 'stylesheet';
-      link.type = 'text/css';
-      link.href = '$revealjs-url$/css/print/pdf.css';
-      document.getElementsByTagName( 'head' )[0].appendChild( link );
-    }
+    var link = document.createElement( 'link' );
+    link.rel = 'stylesheet';
+    link.type = 'text/css';
+    link.href = window.location.search.match( /print-pdf/gi ) ? '$revealjs-url$/css/print/pdf.css' : '$revealjs-url$/css/print/paper.css';
+    document.getElementsByTagName( 'head' )[0].appendChild( link );
   </script>
   <!--[if lt IE 9]>
   <script src="$revealjs-url$/lib/js/html5shiv.js"></script>
@@ -77,32 +75,145 @@ $body$
     </div>
   </div>
 
-
   <script src="$revealjs-url$/lib/js/head.min.js"></script>
   <script src="$revealjs-url$/js/reveal.js"></script>
 
   <script>
 
-      // Full list of configuration options available here:
+      // Full list of configuration options available at:
       // https://github.com/hakimel/reveal.js#configuration
       Reveal.initialize({
-        controls: $if(controls)$$controls$$else$true$endif$,         // Display controls in the bottom right corner
-        progress: $if(progress)$$progress$$else$true$endif$,         // Display a presentation progress bar
-        history: true,          // Push each slide change to the browser history
-        center: $if(center)$$center$$else$false$endif$,                       // Vertical centering of slides
-        maxScale: $if(maxScale)$$maxScale$$else$1.5$endif$,                  // Bounds for smallest/largest possible content scale
-        slideNumber: $if(slideNumber)$true$else$false$endif$,                // Display the page number of the current slide
-        theme: $if(theme)$'$theme$'$else$Reveal.getQueryHash().theme$endif$, // available themes are in /css/theme
-        transition: $if(transition)$'$transition$'$else$Reveal.getQueryHash().transition || 'default'$endif$, // default/cube/page/concave/zoom/linear/fade/none
+$if(controls)$
+        // Display controls in the bottom right corner
+        controls: $controls$,
+$endif$
+$if(progress)$
+        // Display a presentation progress bar
+        progress: $progress$,
+$endif$
+$if(slideNumber)$
+        // Display the page number of the current slide
+        slideNumber: $slideNumber$,
+$endif$
+$if(history)$
+        // Push each slide change to the browser history
+        history: $history$,
+$endif$
+$if(keyboard)$
+        // Enable keyboard shortcuts for navigation
+        keyboard: $keyboard$,
+$endif$
+$if(overview)$
+        // Enable the slide overview mode
+        overview: $overview$,
+$endif$
+$if(center)$
+        // Vertical centering of slides
+        center: $center$,
+$endif$
+$if(touch)$
+        // Enables touch navigation on devices with touch input
+        touch: $touch$,
+$endif$
+$if(loop)$
+        // Loop the presentation
+        loop: $loop$,
+$endif$
+$if(rtl)$
+        // Change the presentation direction to be RTL
+        rtl: $rtl$,
+$endif$
+$if(fragments)$
+        // Turns fragments on and off globally
+        fragments: $fragments$,
+$endif$
+$if(embedded)$
+        // Flags if the presentation is running in an embedded mode,
+        // i.e. contained within a limited portion of the screen
+        embedded: $embedded$,
+$endif$
+$if(help)$
+        // Flags if we should show a help overlay when the questionmark
+        // key is pressed
+        help: $help$,
+$endif$
+$if(showNotes)$
+        // Flags if speaker notes should be visible to all viewers
+        showNotes: $showNotes$,
+$endif$
+$if(autoSlide)$
+        // Number of milliseconds between automatically proceeding to the
+        // next slide, disabled when set to 0, this value can be overwritten
+        // by using a data-autoslide attribute on your slides
+        autoSlide: $autoSlide$,
+$endif$
+$if(autoSlideStoppable)$
+        // Stop auto-sliding after user input
+        autoSlideStoppable: $autoSlideStoppable$,
+$endif$
+$if(mouseWheel)$
+        // Enable slide navigation via mouse wheel
+        mouseWheel: $mouseWheel$,
+$endif$
+$if(hideAddressBar)$
+        // Hides the address bar on mobile devices
+        hideAddressBar: $hideAddressBar$,
+$endif$
+$if(previewLinks)$
+        // Opens links in an iframe preview overlay
+        previewLinks: $previewLinks$,
+$endif$
+$if(transition)$
+        // Transition style
+        transition: '$transition$', // none/fade/slide/convex/concave/zoom
+$endif$
+$if(transitionSpeed)$
+        // Transition speed
+        transitionSpeed: '$transitionSpeed$', // default/fast/slow
+$endif$
+$if(backgroundTransition)$
+        // Transition style for full page slide backgrounds
+        backgroundTransition: '$backgroundTransition$', // none/fade/slide/convex/concave/zoom
+$endif$
+$if(viewDistance)$
+        // Number of slides away from the current that are visible
+        viewDistance: $viewDistance$,
+$endif$
+$if(parallaxBackgroundImage)$
+        // Parallax background image
+        parallaxBackgroundImage: '$parallaxBackgroundImage$', // e.g. "'https://s3.amazonaws.com/hakim-static/reveal-js/reveal-parallax-1.jpg'"
+$endif$
+$if(parallaxBackgroundSize)$
+        // Parallax background size
+        parallaxBackgroundSize: '$parallaxBackgroundSize$', // CSS syntax, e.g. "2100px 900px"
+$endif$
+$if(parallaxBackgroundHorizontal)$
+        // Amount to move parallax background (horizontal and vertical) on slide change
+        // Number, e.g. 100
+        parallaxBackgroundHorizontal: '$parallaxBackgroundHorizontal$',
+$endif$
+$if(parallaxBackgroundVertical)$
+        parallaxBackgroundVertical: '$parallaxBackgroundVertical$',
+$endif$
+$if(margin)$
+        // Factor of the display size that should remain empty around the content
+        margin: $margin$,
+$endif$
+$if(minScale)$
+        // Bounds for smallest/largest possible scale to apply to content
+        minScale: $minScale$,
+$endif$
+$if(maxScale)$
+        maxScale: $maxScale$,
+$endif$
 
-        // Optional libraries used to extend on reveal.js
+        // Optional reveal.js plugins
         dependencies: [
           { src: '$revealjs-url$/lib/js/classList.js', condition: function() { return !document.body.classList; } },
-          { src: '$revealjs-url$/plugin/zoom-js/zoom.js', async: true, condition: function() { return !!document.body.classList; } },
-          { src: '$revealjs-url$/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } },
-//          { src: '$revealjs-url$/plugin/search/search.js', async: true, condition: function() { return !!document.body.classList; }, }
-//          { src: '$revealjs-url$/plugin/remotes/remotes.js', async: true, condition: function() { return !!document.body.classList; } }
-]});
+          { src: '$revealjs-url$/plugin/zoom-js/zoom.js', async: true },
+          { src: '$revealjs-url$/plugin/notes/notes.js', async: true }
+        ]
+      });
     </script>
   $for(include-after)$
   $include-after$


### PR DESCRIPTION
All configuration options are now available as variables, but are only be included in final document if set (reveal.js uses defaults otherwise).

If you approve of this, should we simply indicate that all reveal.js configuration options listed at <https://github.com/hakimel/reveal.js#configuration> can be set as variables, rather than listing all these in the documentation?

Note that <https://github.com/jgm/pandoc/blob/82b3e0ab97a67188f0886dd6b758aa8d0ccd1064/src/Text/Pandoc/Writers/HTML.hs#L195> will set the `center` variable to `true` by default, which doesn't do any harm, but isn't necessary with this template.