### PR TITLE
Use Ligatures=TeX for fontspec.

### DIFF
--- a/default.beamer
+++ b/default.beamer
@@ -40,7 +40,7 @@ $endif$
   \else
     \usepackage{fontspec}
   \fi
-  \defaultfontfeatures{Mapping=tex-text,Scale=MatchLowercase}
+  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
   \newcommand{\euro}{€}
 $if(mainfont)$
     \setmainfont[$mainfontoptions$]{$mainfont$}

--- a/default.latex
+++ b/default.latex
@@ -23,7 +23,7 @@ $endif$
   \else
     \usepackage{fontspec}
   \fi
-  \defaultfontfeatures{Mapping=tex-text,Scale=MatchLowercase}
+  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
   \newcommand{\euro}{€}
 $if(mainfont)$
     \setmainfont[$mainfontoptions$]{$mainfont$}


### PR DESCRIPTION
This avoids the ‘use `Ligatures=TeX` instead of `Mapping=tex-text`’ warning when using LuaTeX. The [manual](http://mirrors.ctan.org/macros/latex/contrib/fontspec/fontspec.pdf) clarifies: 'for consistency `Ligatures=TeX` will perform the same function as `Mapping=tex-text`.'