### PR TITLE
Expand ConTeXt variables; drop MkII support.

### DIFF
--- a/default.context
+++ b/default.context
@@ -1,7 +1,3 @@
-\startmode[*mkii]
-  \enableregime[utf-8]  
-  \setupcolors[state=start]
-\stopmode
 $if(context-lang)$
 \mainlanguage[$context-lang$]
 $endif$
@@ -9,25 +5,68 @@ $if(context-dir)$
 \setupalign[$context-dir$]
 \setupdirections[bidi=on,method=two]
 $endif$
-
 % Enable hyperlinks
-\setupinteraction[state=start, color=middleblue]
+\setupinteraction
+  [state=start$if(style)$,
+  style=$style$$endif$$if(linkcolor)$,
+  color=$linkcolor$,
+  contrastcolor=$linkcolor$$endif$$if(title)$,
+  title=$title$$endif$$if(subtitle)$,
+  subtitle=$subtitle$$endif$$if(author)$,
+  author=$author$$endif$$if(keywords)$,
+  keyword=$keywords$$endif$]
+% make chapter, section bookmarks visible when opening document
+\placebookmarks[chapter,section,subsection,subsubsection][chapter,section]
+\setupinteractionscreen[option=bookmark]
 
-\setuppapersize [$if(papersize)$$papersize$$else$letter$endif$][$if(papersize)$$papersize$$else$letter$endif$]
-\setuplayout    [width=middle,  backspace=1.5in, cutspace=1.5in,
-                 height=middle, topspace=0.75in, bottomspace=0.75in]
-
-\setuppagenumbering[location={footer,center}]
-
-\setupbodyfont[11pt]
-
+$if(papersize)$
+\setuppapersize[$for(papersize)$$papersize$$sep$,
+  $endfor$]
+$endif$
+$if(layout)$
+\setuplayout[$for(layout)$$layout$$sep$,
+  $endfor$]
+$endif$
+$if(pagenumbering)$
+\setuppagenumbering[$for(pagenumbering)$$pagenumbering$$sep$,
+  $endfor$]
+$endif$
+\definefontfeature[default][default][protrusion=quality,expansion=quality,onum=yes] % use microtypography
+\setupalign[hz,hanging]
+\setupbodyfontenvironment[default][em=italic] % use italic as em, not slanted
+$if(mainfont)$
+\definefontfamily[mainfont][serif][$mainfont$]
+$endif$
+$if(sansfont)$
+\definefontfamily[sansfont][sans][$sansfont$]
+$endif$
+$if(monofont)$
+\definefontfamily[monofont][mono][$monofont$][features=none]
+$endif$
+$if(mathfont)$
+\definefontfamily[mathfont][math][$mathfont$]
+$endif$
+\setupbodyfont[mainfont$if(fontsize)$,$fontsize$$endif$]
+$if(whitespace)$
+\setupwhitespace[$whitespace$]
+$else$
 \setupwhitespace[medium]
+$endif$
+$if(interlinespace)$
+\setupinterlinespace[$interlinespace$]
+$endif$
 
 \setuphead[chapter]      [style=\tfd]
 \setuphead[section]      [style=\tfc]
 \setuphead[subsection]   [style=\tfb]
 \setuphead[subsubsection][style=\bf]
 
+$if(headertext)$
+\setupheadertexts[$headertext$]
+$endif$
+$if(footertext)$
+\setupfootertexts[$footertext$]
+$endif$
 $if(number-sections)$
 $else$
 \setuphead[chapter, section, subsection, subsubsection][number=no]
@@ -45,17 +84,6 @@ $endif$
 
 \setupthinrules[width=15em] % width of horizontal rules
 
-\setupdelimitedtext
-  [blockquote]
-  [before={\blank[medium]},
-   after={\blank[medium]},
-   indentnext=no,
-  ]
-
-$if(toc)$
-\setupcombinedlist[content][list={$placelist$}]
-
-$endif$
 $for(header-includes)$
 $header-includes$
 $endfor$
@@ -65,6 +93,10 @@ $if(title)$
 \startalignment[center]
   \blank[2*big]
   {\tfd $title$}
+$if(subtitle)$
+  \blank[3*medium]
+  {\tfa $subtitle$}
+$endif$
 $if(author)$
   \blank[3*medium]
   {\tfa $for(author)$$author$$sep$\crlf $endfor$}
@@ -76,11 +108,24 @@ $endif$
   \blank[3*medium]
 \stopalignment
 $endif$
+$if(abstract)$
+\midaligned{\bf Abstract}
+\startnarrower[2*middle]
+$abstract$
+\stopnarrower
+\blank[big]
+$endif$
 $for(include-before)$
 $include-before$
 $endfor$
 $if(toc)$
-\placecontent
+\completecontent
+$endif$
+$if(lot)$
+\completelistoftables
+$endif$
+$if(lof)$
+\completelistoffigures
 $endif$
 
 $body$


### PR DESCRIPTION
This allows ContTeXt to approach parity with the LaTeX template. Dropping support for MkII (which hasn't been under development since 2007) allows for a simpler and more generic template; hope this is acceptable.