### PR TITLE
Simplify hyperref usage.

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -52,32 +52,20 @@ $endif$
 $if(geometry)$
 \usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
 $endif$
-\makeatletter
-\@ifpackageloaded{hyperref}{}{%
-\ifxetex
-  \usepackage[setpagesize=false, % page size defined by xetex
-              unicode=false, % unicode breaks when used with xetex
-              xetex]{hyperref}
-\else
-  \usepackage[unicode=true]{hyperref}
-\fi
-}
-\@ifpackageloaded{color}{
-    \PassOptionsToPackage{usenames,dvipsnames}{color}
-}{%
-    \usepackage[usenames,dvipsnames]{color}
-}
-\makeatother
+\usepackage{hyperref}
+\PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref
 \hypersetup{breaklinks=true,
-            bookmarks=true,
-            pdfauthor={$author-meta$},
-            pdftitle={$title-meta$},
+            unicode=true,$if(title-meta)$
+            pdftitle={$title-meta$},$endif$$if(author-meta)$
+            pdfauthor={$author-meta$},$endif$$if(subtitle)$
+            pdfsubject={$subtitle$},$endif$$if(keywords)$
+            pdfkeywords={$keywords$},$endif$
             colorlinks=true,
             citecolor=$if(citecolor)$$citecolor$$else$blue$endif$,
             urlcolor=$if(urlcolor)$$urlcolor$$else$blue$endif$,
             linkcolor=$if(linkcolor)$$linkcolor$$else$magenta$endif$,
-            pdfborder={0 0 0}
-            $if(hidelinks)$,hidelinks,$endif$}
+            pdfborder={0 0 0}$if(hidelinks)$,
+            hidelinks$endif$}
 \urlstyle{same}  % don't use monospace font for urls
 $if(lang)$
 \ifxetex

--- a/default.latex
+++ b/default.latex
@@ -61,9 +61,9 @@ $endif$
             pdfsubject={$subtitle$},$endif$$if(keywords)$
             pdfkeywords={$keywords$},$endif$
             colorlinks=true,
-            citecolor=$if(citecolor)$$citecolor$$else$blue$endif$,
-            urlcolor=$if(urlcolor)$$urlcolor$$else$blue$endif$,
-            linkcolor=$if(linkcolor)$$linkcolor$$else$magenta$endif$,
+            citecolor=$if(citecolor)$$citecolor$$else$black$endif$,
+            urlcolor=$if(urlcolor)$$urlcolor$$else$black$endif$,
+            linkcolor=$if(linkcolor)$$linkcolor$$else$black$endif$,
             pdfborder={0 0 0}$if(hidelinks)$,
             hidelinks$endif$}
 \urlstyle{same}  % don't use monospace font for urls


### PR DESCRIPTION
The different usage for `xetex` appears to have been a workaround for bugs fixed in 2009 (see my question on this at <http://tex.stackexchange.com/questions/273339/what-hyperref-options-should-be-used-for-correct-unicode-output>), meaning that the same options can be used for all engines. The `subtitle` is used to set the PDF subject, following ConTeXt. The `bookmarks` option is enabled by default and does not need to be repeated.