### PR TITLE
ConTeXt/LaTeX/Beamer clean-up

### DIFF
--- a/default.beamer
+++ b/default.beamer
@@ -21,7 +21,7 @@ $endif$
 \setbeamertemplate{caption label separator}{: }
 \setbeamercolor{caption name}{fg=normal text.fg}
 $if(fontfamily)$
-\usepackage[$fontfamilyoptions$]{$fontfamily$}
+\usepackage[$for(fontfamilyoptions)$$fontfamilyoptions$$sep$,$endfor$]{$fontfamily$}
 $else$
 \usepackage{lmodern}
 $endif$
@@ -43,20 +43,20 @@ $endif$
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
   \newcommand{\euro}{€}
 $if(mainfont)$
-    \setmainfont[$mainfontoptions$]{$mainfont$}
+    \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 $endif$
 $if(sansfont)$
-    \setsansfont[$sansfontoptions$]{$sansfont$}
+    \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}
 $endif$
 $if(monofont)$
-    \setmonofont[Mapping=tex-ansi$if(monofontoptions)$,$monofontoptions$$endif$]{$monofont$}
+    \setmonofont[Mapping=tex-ansi$if(monofontoptions)$,$for(monofontoptions)$$monofontoptions$$sep$,$endfor$$endif$]{$monofont$}
 $endif$
 $if(mathfont)$
-    \setmathfont(Digits,Latin,Greek)[$mathfontoptions$]{$mathfont$}
+    \setmathfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
 $endif$
 $if(CJKmainfont)$
     \usepackage{xeCJK}
-    \setCJKmainfont[$CJKoptions$]{$CJKmainfont$}
+    \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
 $endif$
 \fi
 % use upquote if available, for straight quotes in verbatim environments
@@ -68,8 +68,10 @@ $endif$
 }{}
 $if(lang)$
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
-  \usepackage[shorthands=off,$for(babel-otherlangs)$$babel-otherlangs$$sep$,$endfor$,main=$babel-lang$]{babel}
+  \usepackage[shorthands=off,$for(babel-otherlangs)$$babel-otherlangs$,$endfor$main=$babel-lang$]{babel}
+$if(babel-newcommands)$
   $babel-newcommands$
+$endif$
 \else
   \usepackage{polyglossia}
   \setmainlanguage[$polyglossia-lang.options$]{$polyglossia-lang.name$}

--- a/default.context
+++ b/default.context
@@ -21,8 +21,8 @@ $if(keywords)$
   keyword={$for(keywords)$$keywords$$sep$; $endfor$},
 $endif$
   style=$if(style)$$style$$else$normal$endif$,
-  color=$if(linkcolor)$$linkcolor$$else$black$endif$,
-  contrastcolor=$if(linkcolor)$$linkcolor$$else$black$endif$]
+  color=$linkcolor$,
+  contrastcolor=$linkcolor$]
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]
 \setupinteractionscreen[option=bookmark]

--- a/default.context
+++ b/default.context
@@ -8,31 +8,38 @@ $endif$
 % Enable hyperlinks
 \setupinteraction
   [state=start,
+$if(title)$
+  title={$title$},
+$endif$
+$if(subtitle)$
+  subtitle={$subtitle$},
+$endif$
+$if(author)$
+  author={$for(author)$$author$$sep$; $endfor$},
+$endif$
+$if(keywords)$
+  keyword={$for(keywords)$$keywords$$sep$; $endfor$},
+$endif$
   style=$if(style)$$style$$else$normal$endif$,
   color=$if(linkcolor)$$linkcolor$$else$black$endif$,
-  contrastcolor=$if(linkcolor)$$linkcolor$$else$black$endif$$if(title)$,
-  title=$title$$endif$$if(subtitle)$,
-  subtitle=$subtitle$$endif$$if(author)$,
-  author=$for(author)$$author$$sep$; $endfor$$endif$$if(keywords)$,
-  keyword=$keywords$$endif$]
+  contrastcolor=$if(linkcolor)$$linkcolor$$else$black$endif$]
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]
 \setupinteractionscreen[option=bookmark]
 \setuptagging[state=start]
 
 $if(papersize)$
-\setuppapersize[$for(papersize)$$papersize$$sep$,
-  $endfor$]
+\setuppapersize[$for(papersize)$$papersize$$sep$,$endfor$]
 $endif$
 $if(layout)$
-\setuplayout[$for(layout)$$layout$$sep$,
-  $endfor$]
+\setuplayout[$for(layout)$$layout$$sep$,$endfor$]
 $endif$
 $if(pagenumbering)$
-\setuppagenumbering[$for(pagenumbering)$$pagenumbering$$sep$,
-  $endfor$]
+\setuppagenumbering[$for(pagenumbering)$$pagenumbering$$sep$,$endfor$]
 $endif$
-\definefontfeature[default][default][protrusion=quality,expansion=quality,onum=yes] % use microtypography
+% use microtypography
+\definefontfeature[default][default][protrusion=quality,expansion=quality,onum=yes,pnum=yes]
+\definefontfeature[smallcaps][smallcaps][protrusion=quality,expansion=quality,onum=yes,pnum=yes]
 \setupalign[hz,hanging]
 \setupbodyfontenvironment[default][em=italic] % use italic as em, not slanted
 $if(mainfont)$
@@ -48,13 +55,12 @@ $if(mathfont)$
 \definefontfamily[mathfont][math][$mathfont$]
 $endif$
 \setupbodyfont[mainfont$if(fontsize)$,$fontsize$$endif$]
-$if(whitespace)$
-\setupwhitespace[$whitespace$]
-$else$
-\setupwhitespace[medium]
+\setupwhitespace[$if(whitespace)$$whitespace$$else$medium$endif$]
+$if(indenting)$
+\setupindenting[$for(indenting)$$indenting$$sep$,$endfor$]
 $endif$
 $if(interlinespace)$
-\setupinterlinespace[$interlinespace$]
+\setupinterlinespace[$for(interlinespace)$$interlinespace$$sep$,$endfor$]
 $endif$
 
 \setuphead[chapter]            [style=\tfd,header=empty]
@@ -65,10 +71,10 @@ $endif$
 \setuphead[subsubsubsubsection][style=\it]
 
 $if(headertext)$
-\setupheadertexts[$headertext$]
+\setupheadertexts$for(headertext)$[$headertext$]$endfor$
 $endif$
 $if(footertext)$
-\setupfootertexts[$footertext$]
+\setupfootertexts$for(footertext)$[$footertext$]$endfor$
 $endif$
 $if(number-sections)$
 $else$

--- a/default.context
+++ b/default.context
@@ -20,7 +20,7 @@ $endif$
 $if(keywords)$
   keyword={$for(keywords)$$keywords$$sep$; $endfor$},
 $endif$
-  style=$if(style)$$style$$else$normal$endif$,
+  style=$linkstyle$,
   color=$linkcolor$,
   contrastcolor=$linkcolor$]
 % make chapter, section bookmarks visible when opening document

--- a/default.context
+++ b/default.context
@@ -22,7 +22,7 @@ $if(keywords)$
 $endif$
   style=$linkstyle$,
   color=$linkcolor$,
-  contrastcolor=$linkcolor$]
+  contrastcolor=$linkcontrastcolor$]
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]
 \setupinteractionscreen[option=bookmark]

--- a/default.latex
+++ b/default.latex
@@ -1,6 +1,6 @@
 \documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
 $if(fontfamily)$
-\usepackage[$fontfamilyoptions$]{$fontfamily$}
+\usepackage[$for(fontfamilyoptions)$$fontfamilyoptions$$sep$,$endfor$]{$fontfamily$}
 $else$
 \usepackage{lmodern}
 $endif$
@@ -26,20 +26,20 @@ $endif$
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
   \newcommand{\euro}{€}
 $if(mainfont)$
-    \setmainfont[$mainfontoptions$]{$mainfont$}
+    \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 $endif$
 $if(sansfont)$
-    \setsansfont[$sansfontoptions$]{$sansfont$}
+    \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}
 $endif$
 $if(monofont)$
-    \setmonofont[Mapping=tex-ansi$if(monofontoptions)$,$monofontoptions$$endif$]{$monofont$}
+    \setmonofont[Mapping=tex-ansi$if(monofontoptions)$,$for(monofontoptions)$$monofontoptions$$sep$,$endfor$$endif$]{$monofont$}
 $endif$
 $if(mathfont)$
-    \setmathfont(Digits,Latin,Greek)[$mathfontoptions$]{$mathfont$}
+    \setmathfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
 $endif$
 $if(CJKmainfont)$
     \usepackage{xeCJK}
-    \setCJKmainfont[$CJKoptions$]{$CJKmainfont$}
+    \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
 $endif$
 \fi
 % use upquote if available, for straight quotes in verbatim environments
@@ -55,11 +55,19 @@ $endif$
 \usepackage{hyperref}
 \PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref
 \hypersetup{breaklinks=true,
-            unicode=true,$if(title-meta)$
-            pdftitle={$title-meta$},$endif$$if(author-meta)$
-            pdfauthor={$author-meta$},$endif$$if(subtitle)$
-            pdfsubject={$subtitle$},$endif$$if(keywords)$
-            pdfkeywords={$keywords$},$endif$
+            unicode=true,
+$if(title-meta)$
+            pdftitle={$title-meta$},
+$endif$
+$if(author-meta)$
+            pdfauthor={$author-meta$},
+$endif$
+$if(subtitle)$
+            pdfsubject={$subtitle$},
+$endif$
+$if(keywords)$
+            pdfkeywords={$for(keywords)$$keywords$$sep$; $endfor$},
+$endif$
             colorlinks=true,
             citecolor=$if(citecolor)$$citecolor$$else$black$endif$,
             urlcolor=$if(urlcolor)$$urlcolor$$else$black$endif$,
@@ -69,8 +77,10 @@ $endif$
 \urlstyle{same}  % don't use monospace font for urls
 $if(lang)$
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
-  \usepackage[shorthands=off,$for(babel-otherlangs)$$babel-otherlangs$$sep$,$endfor$,main=$babel-lang$]{babel}
+  \usepackage[shorthands=off,$for(babel-otherlangs)$$babel-otherlangs$,$endfor$main=$babel-lang$]{babel}
+$if(babel-newcommands)$
   $babel-newcommands$
+$endif$
 \else
   \usepackage{polyglossia}
   \setmainlanguage[$polyglossia-lang.options$]{$polyglossia-lang.name$}

--- a/default.latex
+++ b/default.latex
@@ -54,8 +54,7 @@ $if(geometry)$
 $endif$
 \usepackage{hyperref}
 \PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref
-\hypersetup{breaklinks=true,
-            unicode=true,
+\hypersetup{unicode=true,
 $if(title-meta)$
             pdftitle={$title-meta$},
 $endif$
@@ -68,12 +67,15 @@ $endif$
 $if(keywords)$
             pdfkeywords={$for(keywords)$$keywords$$sep$; $endfor$},
 $endif$
+$if(colorlinks)$
             colorlinks=true,
-            citecolor=$if(citecolor)$$citecolor$$else$black$endif$,
-            urlcolor=$if(urlcolor)$$urlcolor$$else$black$endif$,
-            linkcolor=$if(linkcolor)$$linkcolor$$else$black$endif$,
-            pdfborder={0 0 0}$if(hidelinks)$,
-            hidelinks$endif$}
+            linkcolor=$if(linkcolor)$$linkcolor$$else$Maroon$endif$,
+            citecolor=$if(citecolor)$$citecolor$$else$Blue$endif$,
+            urlcolor=$if(urlcolor)$$urlcolor$$else$Blue$endif$,
+$else$
+            pdfborder={0 0 0},
+$endif$
+            breaklinks=true}
 \urlstyle{same}  % don't use monospace font for urls
 $if(lang)$
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
@@ -206,7 +208,9 @@ $include-before$
 $endfor$
 $if(toc)$
 {
+$if(colorlinks)$
 \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$black$endif$}
+$endif$
 \setcounter{tocdepth}{$toc-depth$}
 \tableofcontents
 }


### PR DESCRIPTION
Edited:

Apologies for the omnibus pull request; can flatten this into one commit or separate them out as desired. This provides several minor improvements:

- Formatting of some conditionals is adjusted to provide cleaner spacing and punctuation in generated preamble.
- `$for$` is always provided where the user might want to use multiple options (does not change existing functionality).
- `hyperref` link rendering revised per discussion in https://github.com/jgm/pandoc-templates/commit/a84f822c30fde1802131c1c7d69d6ebae4550f72:
    - the `hidelinks` option is now effectively the default (and has been removed as a separate option), rather than setting all links to black;
    - link colours can be enabled more easily (using a slightly darker version of the old Pandoc defaults) using a new `colorlinks` variable;
    - `pdfborder={0 0 0}` is automatically enabled in `hyperref` when `colorlinks` is enabled, and is now only applied.
- ConTeXt only:
    - microtype applied to both regular text and small caps;
    - `indenting` variable added;
    - renamed `style` to `linkstyle` for consistency (had not yet made it into the README through my oversight, which I will correct);
    - separated `linkcontrastcolor` from `linkcolor`;
    - matching LaTeX `hyperref` usage, only disable link styling rather than providing a specific setting.

---

Original:

This does not make any changes in functionality to LaTeX or Beamer, but always provides `$for$` where multiple options might be provided, and improves the appearance of the generated source. In ConTeXt, minor improvements are made to typography and an `indenting` variable is added.