### PR TITLE
Fix author, date in AsciiDoc; add keywords, abstract.

### DIFF
--- a/default.asciidoc
+++ b/default.asciidoc
@@ -1,14 +1,23 @@
 $if(titleblock)$
 $title$
-$for(author)$
-:author: $author$
-$endfor$
+$if(author)$
+$for(author)$$author$$sep$; $endfor$
+$endif$
 $if(date)$
-:date: $date$
+$date$
+$endif$
+$if(keywords)$
+:keywords: $for(keywords)$$keywords$$sep$, $endfor$
 $endif$
 $if(toc)$
 :toc:
 $endif$
+
+$endif$
+$if(abstract)$
+[abstract]
+== Abstract
+$abstract$
 
 $endif$
 $for(header-includes)$


### PR DESCRIPTION
AsciiDoctor did not parse previous output correctly. See <http://asciidoctor.org/docs/user-manual/#keywords> on keywords, <http://asciidoctor.org/docs/user-manual/#author-and-email> on author, <http://asciidoctor.org/docs/user-manual/#user-abstract> for abstract.

AsciiDoctor can also take a subtitle, but Pandoc would need to switch to writing ATX-style headers to make this possible (though I think this would also allow for a simplification of the code, as it would likely make the `titleblock` variable unnecessary).