### PR TITLE
Is it possible to add threeparttable as one of the optional importing packages in latex template?

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -103,7 +103,7 @@ $if(verbatim-in-note)$
 \VerbatimFootnotes % allows verbatim text in footnotes
 $endif$
 $if(tables)$
-\usepackage{longtable,booktabs}
+\usepackage{longtable,booktabs,threeparttable}
 $endif$
 $if(graphics)$
 \usepackage{graphicx,grffile}


### PR DESCRIPTION
The `threeparttable` package in LaTeX is a popular and stable table formatting package. It allows us to generate table with caption and table footnote at the same width, which is handy sometimes. This package works really well with `booktabs` and `longtable` and it won't be triggered unless users call `\begin{threeparttable}` in the text. 

What I did in this PR is simply adding `threeparttable` into the list of packages to import when option `tables` is TRUE. I understand that we should try to keep this template as minimum as possible. So please feel free to let me know if you believe it is not necessary to include this package here. :)