### PR TITLE
Issue for title.meta when subtitle is set

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -169,7 +169,7 @@ $if(dir)$
 $endif$
 
 $if(title)$
-\title{$title$$if(subtitle)$\\\vspace{0.5em}{\large $subtitle$}$endif$}
+\title[$title$]{$title$$if(subtitle)$\\\vspace{0.5em}{\large $subtitle$}$endif$}
 $endif$
 $if(author)$
 \author{$for(author)$$author$$sep$ \and $endfor$}


### PR DESCRIPTION
The title of the document in the `hyperref` settings or in the header/footnotes would otherwise be "${title}0.5em${subtitle}".