### PR TITLE
Make color option change dependent on colorlinks.

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -53,7 +53,9 @@ $if(geometry)$
 \usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
 $endif$
 \usepackage{hyperref}
+$if(colorlinks)$
 \PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref
+$endif$
 \hypersetup{unicode=true,
 $if(title-meta)$
             pdftitle={$title-meta$},


### PR DESCRIPTION
The color options are only used for setting the link colour; it is otherwise redundant (someone wanting to add colour to other parts of the document will likely have more complex needs).