### PR TITLE
Make \euro conditional for XeTeX/LuaTeX.

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -24,7 +24,9 @@ $endif$
     \usepackage{fontspec}
   \fi
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
+$if(euro)$
   \newcommand{\euro}{€}
+$endif$
 $if(mainfont)$
     \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 $endif$


### PR DESCRIPTION
Mirrors behaviour for pdfTeX.