### PR TITLE
Make sure disabling hyphenation actually works.

### DIFF
--- a/default.man
+++ b/default.man
@@ -8,12 +8,12 @@ $endif$
 $if(adjusting)$
 .ad $adjusting$
 $endif$
+.TH "$title$" "$section$" "$date$" "$footer$" "$header$"
 $if(hyphenate)$
 .hy
 $else$
-.nh
+.nh \" Turn off hyphenation by default.
 $endif$
-.TH "$title$" "$section$" "$date$" "$footer$" "$header$"
 $for(header-includes)$
 $header-includes$
 $endfor$


### PR DESCRIPTION
For some reason, `.nh` does not work if specified _prior to_ `.TH`. If `.nh` is below `.TH`, hyphenation is properly disabled.