### PR TITLE
Make \euro conditional in Beamer for XeTeX/LuaTeX.

### DIFF
--- a/default.beamer
+++ b/default.beamer
@@ -42,7 +42,9 @@ $endif$
     \usepackage{fontspec}
   \fi
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
+$if(euro)$
   \newcommand{\euro}{€}
+$endif$
 $if(mainfont)$
     \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 $endif$


### PR DESCRIPTION
Implements the change made for LaTeX in <https://github.com/jgm/pandoc-templates/commit/e45a3fac77e5bd876b20a6b8a0dcbf54f5aa12ab>.