### PR TITLE
pdflatex & xelatex fixes

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -12,6 +12,7 @@ $endif$
 \usepackage{ifxetex,ifluatex}
 \usepackage{fixltx2e} % provides \textsubscript
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \usepackage{cmap}
   \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
   \usepackage[utf8]{inputenc}
 $if(euro)$
@@ -23,7 +24,7 @@ $endif$
   \else
     \usepackage{fontspec}
   \fi
-  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
+  \defaultfontfeatures{$if(deffontfeatures)$$deffontfeatures$$else$Ligatures=TeX,Scale=MatchLowercase$endif$}
 $if(euro)$
   \newcommand{\euro}{€}
 $endif$


### PR DESCRIPTION
- cmap for pdflatex allows searching and copying from pdfs for non-ASCII documents
- \defaultfontfeatures allows to workaround known xelatex crash for cyrillic texts