### PR TITLE
Semantically enclose content for HTML & HTML5 targets.

### DIFF
--- a/default.html
+++ b/default.html
@@ -56,7 +56,9 @@ $if(toc)$
 $toc$
 </div>
 $endif$
+<div id="$idprefix$CONTENT">
 $body$
+</div>
 $for(include-after)$
 $include-after$
 $endfor$

--- a/default.html5
+++ b/default.html5
@@ -59,7 +59,9 @@ $if(toc)$
 $toc$
 </nav>
 $endif$
+<article id="$idprefix$CONTENT">
 $body$
+</article>
 $for(include-after)$
 $include-after$
 $endfor$


### PR DESCRIPTION
 Can already be done using include-before and include-after, but looks more consistent as suggested.