### PR TITLE
default.latex: added variables to adjust maximum figure width/heigth.

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -122,8 +122,8 @@ $endif$
 $if(graphics)$
 \usepackage{graphicx,grffile}
 \makeatletter
-\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
-\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+\def\maxwidth{$if(fig-max-w)$$fig-max-w$$endif$\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\def\maxheight{$if(fig-max-h)$$fig-max-h$$endif$\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
 \makeatother
 % Scale images if necessary, so that they will not overflow the page
 % margins by default, and it is still possible to overwrite the defaults


### PR DESCRIPTION
fig-max-w: maximum proportion of the linewidth a figure can take.
fig-max-h: maximum proportion of the textheigth a figure can take.

For image-heavy documents where the current limitation to margin boundaries produces image that are too big; e.g. only one roughly square graphic can fit on a single page.

