### PR TITLE
adds fallback to textcomp for textquotesingle

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -44,8 +44,13 @@ $if(CJKmainfont)$
     \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
 $endif$
 \fi
+
 % use upquote if available, for straight quotes in verbatim environments
-\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+% and fall back to textcomp
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{
+  \IfFileExists{textcomp.sty}{\usepackage{textcomp}}{}
+}
+
 % use microtype if available
 \IfFileExists{microtype.sty}{%
 \usepackage{microtype}


### PR DESCRIPTION
I ran into https://github.com/jgm/pandoc/issues/2439 using a single quote inside a code section (converting from markdown to pdf) and I don't have the upquote package installed, so this resolves that issue for me.