### PR TITLE
natbib: move bibliographystyle from preamble to document

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -94,7 +94,6 @@ $endfor$
 $endif$
 $if(natbib)$
 \usepackage{natbib}
-\bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
 $endif$
 $if(biblatex)$
 \usepackage$if(biblio-style)$[style=$biblio-style$]$endif${biblatex}
@@ -243,6 +242,7 @@ $if(book-class)$
 $else$
 \renewcommand\refname{$biblio-title$}
 $endif$
+\bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
 $endif$
 \bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
 


### PR DESCRIPTION
As far as I can tell, natbib needs the `\bibliographystyle` command in the document, not the preamble. The documentation suggests putting it immediately after `begin{document}`, but it works fine when it is placed together with the `\bibliography` and `\printbibliography` commands at the end of the document.