### PR TITLE
Load "beamerarticle" first (if needed)

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -1,4 +1,7 @@
 \documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$paper,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
+$if(beamerarticle)$
+\usepackage{beamerarticle} % needs to be loaded first
+$endif$
 $if(fontfamily)$
 \usepackage[$for(fontfamilyoptions)$$fontfamilyoptions$$sep$,$endfor$]{$fontfamily$}
 $else$


### PR DESCRIPTION
The beamerarticle package needs to be loaded directly after the documentclass
declaration. Loading it later (e.g. using the -H option) leads to several
errors due to package dependencies.

This patch also introduces a new variable "beamerarticle" to activate the
beamerarticle package.