### PR TITLE
LaTeX: Set figure placement defaults.

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -190,6 +190,11 @@ $if(dir)$
   \newenvironment{LTR}{\beginL}{\endL}
 \fi
 $endif$
+
+\makeatletter
+\def\fps@figure{htbp}
+\makeatother
+
 $for(header-includes)$
 $header-includes$
 $endfor$


### PR DESCRIPTION
This restores Pandoc's defaults after applicaiton of changes in
https://github.com/jgm/pandoc/pull/3093.