### PR TITLE
Custom font families for beamer template

### DIFF
--- a/default.beamer
+++ b/default.beamer
@@ -24,6 +24,9 @@ $endif$
     \usepackage{fontspec}
   \fi
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
+$for(fontfamilies)$
+  \newfontfamily{$fontfamilies.name$}[$fontfamilies.options$]{$fontfamilies.font$}
+$endfor$
 $if(euro)$
   \newcommand{\euro}{€}
 $endif$


### PR DESCRIPTION
Adding ability to define custom font families. Needed for correct `polyglossia` operation with Cyrillic fonts and perhaps can find some other usages. Example usage in YAML metadata:

```
fontfamilies:
- name: \cyrillicfont
  font: Liberation Serif
- name: \cyrillicfonttt
  options: Scale=MatchLowercase
  font: Liberation Mono
```