### PR TITLE
Put only one heading element in top-level header

### DIFF
--- a/default.html5
+++ b/default.html5
@@ -44,13 +44,13 @@ $if(title)$
 <header>
 <h1 class="title">$title$</h1>
 $if(subtitle)$
-<h1 class="subtitle">$subtitle$</h1>
+<p class="subtitle">$subtitle$</p>
 $endif$
 $for(author)$
-<h2 class="author">$author$</h2>
+<p class="author">$author$</p>
 $endfor$
 $if(date)$
-<h3 class="date">$date$</h3>
+<p class="date">$date$</p>
 $endif$
 </header>
 $endif$


### PR DESCRIPTION
Every heading element semantically creates a new section.  Three
consecutive heading elements, e.g. `<h1></h1>`, `<h2></h2>`,
`<h3></h3>`,  semantically equivallent to a section with two
subsections.  This is not the intended meaning of subtitle, author, and
date, making plain `<p>` elements the better choice.  This is one of
the W3C's [common idioms].

This change is the result of discussions on issue jgm/pandoc#3119.

[common idioms]: https://www.w3.org/TR/html5/common-idioms.html#common-idioms

Fixes: jgm/pandoc#3119