### PR TITLE
Add hypersetup options to beamer templates

### DIFF
--- a/default.beamer
+++ b/default.beamer
@@ -97,6 +97,25 @@ $for(bibliography)$
 \addbibresource{$bibliography$}
 $endfor$
 $endif$
+\hypersetup{
+$if(title-meta)$
+            pdftitle={$title-meta$},
+$endif$
+$if(author-meta)$
+            pdfauthor={$author-meta$},
+$endif$
+$if(keywords)$
+            pdfkeywords={$for(keywords)$$keywords$$sep$; $endfor$},
+$endif$
+$if(colorlinks)$
+            colorlinks=true,
+            linkcolor=$if(linkcolor)$$linkcolor$$else$Maroon$endif$,
+            citecolor=$if(citecolor)$$citecolor$$else$Blue$endif$,
+            urlcolor=$if(urlcolor)$$urlcolor$$else$Blue$endif$,
+$else$
+            pdfborder={0 0 0},
+$endif$
+            breaklinks=true}
 $if(listings)$
 \usepackage{listings}
 $endif$


### PR DESCRIPTION
I'm not sure if there is a reason why these were withheld from the
default beamer template, but it seemed to work when I added it in to my
Beamer project.

There was some previous discussion about this at jgm/pandoc#1600.