### PR TITLE
DZSlides: Force word wrapping in code tags

### DIFF
--- a/default.dzslides
+++ b/default.dzslides
@@ -12,7 +12,7 @@ $if(keywords)$
   <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$">
 $endif$
   <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
-  <style type="text/css">code{white-space: pre;}</style>
+  <style type="text/css">code{white-space: pre-wrap;}</style>
 $if(quotes)$
   <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
 $endif$


### PR DESCRIPTION
For instance, if you try to compile the following markdown code with pandoc (using 1.12):

``` markdown
Page 1
------

    This is a very long code line that will appear on every slide even on page three

Page 2
------

My content

Page 3
------

My last content
```

using this command:

    pandoc -s -t dzslides test.md -o test.html

the long code line will appear on every slide. Using pre-wrap fixes the problem by forcing word wrap of code. The only drawback is that it requires IE 8 [according to MDN](https://developer.mozilla.org/fr/docs/Web/CSS/white-space), which make it less compatible.

A workaround it to wrap the code when writing it, but if you consider inline code tags using the accents \`\` in markdown this is not possible.