### PR TITLE
Keyword definition used wrong separator

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -72,7 +72,7 @@ $if(author-meta)$
             pdfauthor={$author-meta$},
 $endif$
 $if(keywords)$
-            pdfkeywords={$for(keywords)$$keywords$$sep$; $endfor$},
+            pdfkeywords={$for(keywords)$$keywords$$sep$, $endfor$},
 $endif$
 $if(colorlinks)$
             colorlinks=true,


### PR DESCRIPTION
The option pdfkeywords from hyperref needs keywords separated with a comma `,` instead of a semicolon `;`.