### PR TITLE
Japanese support in LaTeX template for LuaLaTeX.

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -45,10 +45,21 @@ $endif$
 $if(mathfont)$
     \setmathfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
 $endif$
+  \ifxetex
 $if(CJKmainfont)$
     \usepackage{xeCJK}
     \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
 $endif$
+  \fi
+  \ifluatex
+    \usepackage[$for(luatexjafontspecoptions)$$luatexjafontspecoptions$$sep$,$endfor$]{luatexja-fontspec}
+$if(luatexjapresetoptions)$
+    \usepackage[$for(luatexjapresetoptions)$$luatexjapresetoptions$$sep$,$endfor$]{luatexja-preset}
+$endif$
+$if(CJKmainfont)$
+    \setmainjfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
+$endif$
+  \fi
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}

--- a/default.latex
+++ b/default.latex
@@ -52,11 +52,11 @@ $if(CJKmainfont)$
 $endif$
   \fi
   \ifluatex
-    \usepackage[$for(luatexjafontspecoptions)$$luatexjafontspecoptions$$sep$,$endfor$]{luatexja-fontspec}
 $if(luatexjapresetoptions)$
     \usepackage[$for(luatexjapresetoptions)$$luatexjapresetoptions$$sep$,$endfor$]{luatexja-preset}
 $endif$
 $if(CJKmainfont)$
+    \usepackage[$for(luatexjafontspecoptions)$$luatexjafontspecoptions$$sep$,$endfor$]{luatexja-fontspec}
     \setmainjfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
 $endif$
   \fi


### PR DESCRIPTION
Allow setting Japanese fonts when using LuaLaTeX by using the
`luatexja-fontspec` and `luatexja-preset` packages. Use existing
`CJKmainfont` and `CJKoptions` template variables. Add
`luatexjafontspecoptions` for `luatexja-fontspec` and
`luatexjapresetoptions` for `luatexja-preset`.