### PR TITLE
Allow passing options to `microtype` LaTeX package

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -54,7 +54,7 @@ $endif$
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}
 % use microtype if available
 \IfFileExists{microtype.sty}{%
-\usepackage{microtype}
+\usepackage[$for(microtypeoptions)$$microtypeoptions$$sep$,$endfor$]{microtype}
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
 $if(geometry)$


### PR DESCRIPTION
This change allows me to tweak microtype settings. In particular, I am interested in being able to change font stretching/shrinking values.