### PR TITLE
allow natbib options

### DIFF
--- a/default.beamer
+++ b/default.beamer
@@ -88,7 +88,7 @@ $endfor$
 $endif$
 \newif\ifbibliography
 $if(natbib)$
-\usepackage{natbib}
+\usepackage$if(natbiboptions)$[$for(natbiboptions)$$natbiboptions$$sep$,$endfor$]$endif${natbib}
 \bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
 $endif$
 $if(biblatex)$

--- a/default.latex
+++ b/default.latex
@@ -99,7 +99,7 @@ $endfor$
 \fi
 $endif$
 $if(natbib)$
-\usepackage{natbib}
+\usepackage$if(natbiboptions)$[$for(natbiboptions)$$natbiboptions$$sep$,$endfor$]$endif${natbib}
 \bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
 $endif$
 $if(biblatex)$


### PR DESCRIPTION
I've recently had the need to fiddle with natbib options.  This PR would introduce the variable / option `natbiboptions` to the LaTeX and Beamer templates.

If this change is ultimately merged, should I create a PR in [jgm/pandoc](https://github.com/jgm/pandoc) to document this new variable?  Thanks!