### PR TITLE
Use `unicode-math`.

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -25,11 +25,9 @@ $if(mathspec)$
   \ifxetex
     \usepackage{mathspec}
   \else
-    \usepackage{fontspec}
     \usepackage{unicode-math}
   \fi
 $else$
-  \usepackage{fontspec}
   \usepackage{unicode-math}
 $endif$
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}

--- a/default.latex
+++ b/default.latex
@@ -56,6 +56,7 @@ $if(mathspec)$
 $else$
   \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
 $endif$
+$endif$
 $if(CJKmainfont)$
     \usepackage{xeCJK}
     \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}

--- a/default.latex
+++ b/default.latex
@@ -21,11 +21,17 @@ $if(euro)$
   \usepackage{eurosym}
 $endif$
 \else % if luatex or xelatex
+$if(mathspec)$
   \ifxetex
     \usepackage{mathspec}
   \else
     \usepackage{fontspec}
+    \usepackage{unicode-math}
   \fi
+$else$
+  \usepackage{fontspec}
+  \usepackage{unicode-math}
+$endif$
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
 $for(fontfamilies)$
   \newfontfamily{$fontfamilies.name$}[$fontfamilies.options$]{$fontfamilies.font$}
@@ -43,7 +49,14 @@ $if(monofont)$
     \setmonofont[Mapping=tex-ansi$if(monofontoptions)$,$for(monofontoptions)$$monofontoptions$$sep$,$endfor$$endif$]{$monofont$}
 $endif$
 $if(mathfont)$
+$if(mathspec)$
+  \ifxetex
     \setmathfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+  \else
+    \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+  \fi
+$else$
+  \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
 $endif$
 $if(CJKmainfont)$
     \usepackage{xeCJK}


### PR DESCRIPTION
Use `mathspec` only with XeLaTeX on request.

It seems that [`mathspec`](http://tex.stackexchange.com/a/118273/28495) serves a slightly different purpose than `unicode-math`. For consistency between XeLaTeX and LuaLaTeX, it seems better to prefer `unicode-math`. This pull request still allows use of `mathspec` when it is request by defining synonymous variable.

I suggest this to be applied instead of #183 and #103.