### PR TITLE
LaTeX: Load geometry package after hyperref.

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -89,7 +89,6 @@ $if(verbatim-in-note)$
 \VerbatimFootnotes % allows verbatim text in footnotes
 $endif$
 $if(geometry)$
-% hyperref should be loaded before geometry
 \usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
 $endif$
 $if(lang)$

--- a/default.latex
+++ b/default.latex
@@ -89,8 +89,7 @@ $if(verbatim-in-note)$
 \VerbatimFootnotes % allows verbatim text in footnotes
 $endif$
 $if(geometry)$
-% With mag ≠ 1000, no truedimen and hyperref, hyperref should be loaded before
-% geometry. Otherwise the resulted PDF size will become wrong.
+% hyperref should be loaded before geometry
 \usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
 $endif$
 $if(lang)$

--- a/default.latex
+++ b/default.latex
@@ -57,9 +57,6 @@ $endif$
 \usepackage[$for(microtypeoptions)$$microtypeoptions$$sep$,$endfor$]{microtype}
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
-$if(geometry)$
-\usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
-$endif$
 \PassOptionsToPackage{hyphens}{url} % url is loaded by hyperref
 $if(verbatim-in-note)$
 \usepackage{fancyvrb}
@@ -90,6 +87,11 @@ $endif$
 \urlstyle{same}  % don't use monospace font for urls
 $if(verbatim-in-note)$
 \VerbatimFootnotes % allows verbatim text in footnotes
+$endif$
+$if(geometry)$
+% With mag ≠ 1000, no truedimen and hyperref, hyperref should be loaded before
+% geometry. Otherwise the resulted PDF size will become wrong.
+\usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
 $endif$
 $if(lang)$
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex


### PR DESCRIPTION
This implements suggestion from geometry package manual section 9 Known
problems:

> With mag ≠ 1000, no truedimen and hyperref, hyperref should be loaded
> before geometry. Otherwise the resulted PDF size will become wrong.