### PR TITLE
improved font handling in ConTeXt

### DIFF
--- a/default.context
+++ b/default.context
@@ -23,8 +23,12 @@ $endif$
   style=$linkstyle$,
   color=$linkcolor$,
   contrastcolor=$linkcontrastcolor$]
+$if(colorlinks)$\enabledirectives[references.border$if(linkcolor)$=$linkcolor$$endif$]$endif$
+\enabledirectives[hyphenators.urls.packslashes] %% to avoid having a backslash in each line (http://)
+
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]
+
 \setupinteractionscreen[option=bookmark]
 \setuptagging[state=start]
 
@@ -37,23 +41,22 @@ $endif$
 $if(pagenumbering)$
 \setuppagenumbering[$for(pagenumbering)$$pagenumbering$$sep$,$endfor$]
 $endif$
+
 % use microtypography
 \definefontfeature[default][default][script=latn, protrusion=quality, expansion=quality, itlc=yes, textitalics=yes, onum=yes, pnum=yes]
 \definefontfeature[smallcaps][script=latn, protrusion=quality, expansion=quality, smcp=yes, onum=yes, pnum=yes]
 \setupalign[hz,hanging]
 \setupitaliccorrection[global, always]
+
 \setupbodyfontenvironment[default][em=italic] % use italic as em, not slanted
+
 \definefallbackfamily[mainface][rm][DejaVu Serif][preset=range:greek, force=yes]
-$if(mainfont)$
-\definefontfamily[mainface][rm][$mainfont$]
-\definefontfamily[mainface][mm][$if(mathfont)$$mathfont$$else$TeX Gyre Math$endif$]
-$endif$
-$if(sansfont)$
-\definefontfamily[mainface][tt][$sansfont$]
-$endif$
-$if(monofont)$
-\definefontfamily[mainface][tt][$monofont$][features=none]
-$endif$
+\definefontfamily[mainface][rm][$if(mainfont)$$mainfont$$else$Latin Modern Roman$endif$]
+\definefontfamily[mainface][mm][$if(mathfont)$$mathfont$$else$Latin Modern Math$endif$]
+\definefontfamily[mainface][ss][$if(sansfont)$$sansfont$$else$Latin Modern Sans$endif$]
+\definefontfamily[mainface][tt][$if(monofont)$$monofont$$else$Latin Modern Typewriter$endif$][features=none]
+\setupbodyfont[mainface$if(fontsize)$,$fontsize$$endif$]
+
 \setupwhitespace[$if(whitespace)$$whitespace$$else$medium$endif$]
 $if(indenting)$
 \setupindenting[$for(indenting)$$indenting$$sep$,$endfor$]
@@ -61,7 +64,6 @@ $endif$
 $if(interlinespace)$
 \setupinterlinespace[$for(interlinespace)$$interlinespace$$sep$,$endfor$]
 $endif$
-\setupbodyfont[mainface$if(fontsize)$,$fontsize$$endif$]
 
 \setuphead[chapter]            [style=\tfd,header=empty]
 \setuphead[section]            [style=\tfc]

--- a/default.context
+++ b/default.context
@@ -43,19 +43,16 @@ $endif$
 \setupalign[hz,hanging]
 \setupitaliccorrection[global, always]
 \setupbodyfontenvironment[default][em=italic] % use italic as em, not slanted
-\usemodule[simplefonts$if(fontsize)$,$fontsize$$endif$]
-\setmainfontfallback[DejaVu Serif][range={greekandcoptic, greekextended}, force=yes, rscale=auto]
+\definefallbackfamily[mainface][rm][DejaVu Serif][preset=range:greek, force=yes]
 $if(mainfont)$
-\setmainfont[$mainfont$]
+\definefontfamily[mainface][rm][$mainfont$]
+\definefontfamily[mainface][mm][$if(mathfont)$$mathfont$$else$TeX Gyre Math$endif$]
 $endif$
 $if(sansfont)$
-\setsansfont[$sansfont$][rscale=auto]
+\definefontfamily[mainface][tt][$sansfont$]
 $endif$
 $if(monofont)$
-\setmonofont[$monofont$][features=none, rscale=auto]
-$endif$
-$if(mathfont)$
-\setmathfont[$mathfont$][rscale=auto]
+\definefontfamily[mainface][tt][$monofont$][features=none]
 $endif$
 \setupwhitespace[$if(whitespace)$$whitespace$$else$medium$endif$]
 $if(indenting)$
@@ -64,6 +61,7 @@ $endif$
 $if(interlinespace)$
 \setupinterlinespace[$for(interlinespace)$$interlinespace$$sep$,$endfor$]
 $endif$
+\setupbodyfont[mainface$if(fontsize)$,$fontsize$$endif$]
 
 \setuphead[chapter]            [style=\tfd,header=empty]
 \setuphead[section]            [style=\tfc]


### PR DESCRIPTION
I have removed the `simplefonts` module (now obsolete in ConTeXt).

And I have added optional `linkcolor` for urls (ConTeXt has a single color for all links).