### PR TITLE
replace CMU Serif as Greek fallback typeface

### DIFF
--- a/default.context
+++ b/default.context
@@ -54,7 +54,7 @@ $endif$
 
 \setupbodyfontenvironment[default][em=italic] % use italic as em, not slanted
 
-\definefallbackfamily[mainface][rm][DejaVu Serif][preset=range:greek, force=yes]
+\definefallbackfamily[mainface][rm][CMU Serif][preset=range:greek, force=yes]
 \definefontfamily[mainface][rm][$if(mainfont)$$mainfont$$else$Latin Modern Roman$endif$]
 \definefontfamily[mainface][mm][$if(mathfont)$$mathfont$$else$Latin Modern Math$endif$]
 \definefontfamily[mainface][ss][$if(sansfont)$$sansfont$$else$Latin Modern Sans$endif$]


### PR DESCRIPTION
As described in jgm/pandoc#4405, having a better fallback typeface for Greek (if we must have one) is important to get better typographic results.