### PR TITLE
Use metadata date in context documents

### DIFF
--- a/default.context
+++ b/default.context
@@ -24,6 +24,16 @@ $endif$
   color=$linkcolor$,
   contrastcolor=$linkcontrastcolor$]
 
+$if(date)$
+\ctxlua{
+local date=utilities.parsers.totime('$date$ 00:00');
+if date then
+	table.merge(tex, date); 
+	context('\\normalmonth='..tex.month);
+end;
+}
+$endif$
+
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]
 \setupinteractionscreen[option=bookmark]


### PR DESCRIPTION
The `date` variable set in the metadata is currently unused.

This PR tries to parse the date (`$date` either as `dd/mm/yyyy`, `dd-mm-yyyy`, `yyyy/mm/dd` or `yyyy-mm-dd`; as soon as `$date-meta$` is set in TeX document it should be used instead) and sets the date so \currentdate et al. show the metadata date instead of the document compilation date.

Example document:

```
---
date: 2015-01-03
title: Date test
...

\currentdate
```

Output:
```
Date test
2015-01-03

January 3, 2015
```