### PR TITLE
Keep the \author{} command even if author is empty

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -383,9 +383,7 @@ $else$
 $endif$
 \subtitle{$subtitle$}
 $endif$
-$if(author)$
 \author{$for(author)$$author$$sep$ \and $endfor$}
-$endif$
 \date{$date$}
 $if(beamer)$
 $if(institute)$


### PR DESCRIPTION
otherwise there will be a LaTeX warning "No \author given". See https://www.overleaf.com/learn/latex/Errors/No_%5Cauthor_given