### PR TITLE
preserveAspectRatio="xMidYMid"

### DIFF
--- a/default.epub3
+++ b/default.epub3
@@ -49,7 +49,7 @@ $endif$
 $else$
 $if(coverpage)$
 <div id="cover-image">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="100%" height="100%" viewBox="0 0 $cover-image-width$ $cover-image-height$" preserveAspectRatio="none">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="100%" height="100%" viewBox="0 0 $cover-image-width$ $cover-image-height$" preserveAspectRatio="xMidYMid">
 <image width="$cover-image-width$" height="$cover-image-height$" xlink:href="../media/$cover-image$" />
 </svg>
 </div>
@@ -65,4 +65,3 @@ $endif$
 $endif$
 </body>
 </html>
-


### PR DESCRIPTION
- as-is: preserveAspectRatio="none"
- to-be:  preserveAspectRatio="xMidYMid"

It is not bad to have a full screen, but the cover image is distorted because the aspect ratio is not preserved.