### PR TITLE
add abstract to default html template

### DIFF
--- a/default.html4
+++ b/default.html4
@@ -46,6 +46,12 @@ $endfor$
 $if(date)$
 <h3 class="date">$date$</h3>
 $endif$
+$if(abstract)$
+<div class="abstract">
+<p class="abstract">Abstract</p>
+$abstract$
+</div>
+$endif$
 </div>
 $endif$
 $if(toc)$

--- a/default.html5
+++ b/default.html5
@@ -49,6 +49,12 @@ $endfor$
 $if(date)$
 <p class="date">$date$</p>
 $endif$
+$if(abstract)$
+<div class="abstract">
+<p class="abstract">Abstract</p>
+$abstract$
+</div>
+$endif$
 </header>
 $endif$
 $if(toc)$

--- a/styles.html
+++ b/styles.html
@@ -161,6 +161,16 @@ div.csl-entry {
 $if(csl-entry-spacing)$
   margin-bottom: $csl-entry-spacing$;
 $endif$
+$if(abstract)$
+p.abstract{
+  text-align: center;
+  font-weight: bold;
+}
+div.abstract{
+  margin: auto;
+  width: 90%;
+}
+$endif$
 }
 .hanging div.csl-entry {
   margin-left:2em;


### PR DESCRIPTION
This adds an (optional) abstract to the default html template to go along with the abstract in other formats (LaTeX, ConTeXt, AsciiDoc, and docx, see https://pandoc.org/MANUAL.html#metadata-variables). It is inspired by the default html template of Rmarkdown (https://github.com/rstudio/rmarkdown/blob/main/inst/rmd/h/default.html) and makes switching formats more seamless.