### PR TITLE
Fix background image in Beamer when there are other images

### DIFF
--- a/default.latex
+++ b/default.latex
@@ -33,6 +33,9 @@ $if(background-image)$
 \usebackgroundtemplate{%
   \includegraphics[width=\paperwidth]{$background-image$}%
 }
+% In beamer background-image does not work well when other images are used, so this is the workaround
+\pgfdeclareimage[width=\paperwidth,height=\paperheight]{background}{$background-image$}
+\usebackgroundtemplate{\pgfuseimage{background}}
 $endif$
 \usepackage{pgfpages}
 \setbeamertemplate{caption}[numbered]


### PR DESCRIPTION
In Beamer the background image does not use the 100% of the slides when the presentation contains other images, this workaround fix the issue.