### PR TITLE
Update default.typst to support CSL

### DIFF
--- a/default.typst
+++ b/default.typst
@@ -83,7 +83,10 @@ $endif$
 $body$
 
 $if(citations)$
-$if(bibliographystyle)$
+$if(csl)$
+
+#set bibliography(style: "$csl$")
+$elseif(bibliographystyle)$
 
 #set bibliography(style: "$bibliographystyle$")
 $endif$


### PR DESCRIPTION
Typst now supports CSL: https://typst.app/docs/reference/meta/bibliography/ — so we should support it in the template, in this case if `csl` metadata is present use this otherwise check if `bibliographystyle` is present