### PR TITLE
[beamer] include fonts.latex before setting beamer theme

### DIFF
--- a/default.beamer
+++ b/default.beamer
@@ -62,6 +62,7 @@ $endif$
 $for(beameroption)$
 \setbeameroption{$beameroption$}
 $endfor$
+$fonts.latex()$
 $-- Set Beamer theme before user font settings so they can override theme
 $if(theme)$
 \usetheme[$for(themeoptions)$$themeoptions$$sep$,$endfor$]{$theme$}
@@ -98,7 +99,6 @@ $if(section-titles)$
   \frame{\subsectionpage}
 }
 $endif$
-$fonts.latex()$
 $common.latex()$
 $for(header-includes)$
 $header-includes$


### PR DESCRIPTION
Including fonts.latex after setting the beamer theme, without declaring a mainfont, overrides the theme font with lmodern. Moving the include of fonts.latex before setting the beamer theme fixes this and still allows mainfont to override the theme font. The other option would be not to include fonts.latex at all, and just revert the removal of the contents of fonts.latex from default.beamer, so that the rest of the font options are declared after setting the beamer theme.