### PR TITLE
Implement "dark mode" in default HTML style template

### DIFF
--- a/styles.html
+++ b/styles.html
@@ -1,4 +1,7 @@
 $if(document-css)$
+:root {
+  color-scheme: light dark;
+}
 html {
 $if(mainfont)$
   font-family: $mainfont$;
@@ -9,8 +12,8 @@ $endif$
 $if(linestretch)$
   line-height: $linestretch$;
 $endif$
-  color: $if(fontcolor)$$fontcolor$$else$#1a1a1a$endif$;
-  background-color: $if(backgroundcolor)$$backgroundcolor$$else$#fdfdfd$endif$;
+  color: $if(fontcolor)$$fontcolor$$else$light-dark(#1a1a1a, #fdfdfd)$endif$;
+  background-color: $if(backgroundcolor)$$backgroundcolor$$else$light-dark(#fdfdfd, #1a1a1a)$endif$;
 }
 body {
   margin: 0 auto;
@@ -54,10 +57,10 @@ p {
   margin: 1em 0;
 }
 a {
-  color: $if(linkcolor)$$linkcolor$$else$#1a1a1a$endif$;
+  color: $if(linkcolor)$$linkcolor$$else$light-dark(#1a1a1a, #fdfdfd)$endif$;
 }
 a:visited {
-  color: $if(linkcolor)$$linkcolor$$else$#1a1a1a$endif$;
+  color: $if(linkcolor)$$linkcolor$$else$light-dark(#1a1a1a, #fdfdfd)$endif$;
 }
 img {
   max-width: 100%;
@@ -130,7 +133,7 @@ pre code {
  overflow: visible;
 }
 hr {
-  background-color: #1a1a1a;
+  background-color: light-dark(#1a1a1a, #fdfdfd);
   border: none;
   height: 1px;
   margin: 1em 0;


### PR DESCRIPTION
The `light-dark()` CSS function enables setting both a light and a dark `color` and `background-color` for the HTML document. It will return one of the two colors options by detecting if the user has requested light or dark color theme. 

See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) for more details.

Example results of `pandoc --standalone --output README.html README.md`:

<img src="https://github.com/user-attachments/assets/dcd26e56-73eb-400b-9dbe-9220ba9fa13a" alt="light mode example" width="362">
<img src="https://github.com/user-attachments/assets/1853b5fe-b30d-4e45-8429-c6cf7810c496" alt="dark mode example" width="362">