### PR TITLE
remove css warning on weasyprint

### DIFF
--- a/styles.html
+++ b/styles.html
@@ -185,8 +185,10 @@ header {
 }
 $endif$
 span.smallcaps{font-variant: small-caps;}
+@media screen {
 div.columns{display: flex; gap: min(4vw, 1.5em);}
 div.column{flex: auto; overflow-x: auto;}
+}
 div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
 /* The extra [class] is a hack that increases specificity enough to
    override a similar rule in reveal.js */


### PR DESCRIPTION
Issue
-----
Styles unconditionally emits CSS that uses screen-only properties. Paged-media engines (weasyprint, prince, pagedjs) have no viewport and complain. Fix is to hide these properties from the engines.

Thanks for the wonderful `pandoc`.

Before
------
Building any document with `pandoc --pdf-engine=weasyprint` prints:

    WARNING: Ignored `gap: min(4vw, 1.5em)` at 6:32, invalid value.
    WARNING: Ignored `overflow-x: auto` at 7:28, unknown property.

After
-----
Same two rules, wrapped in `@media screen { ... }`. HTML browsers render identically. Print engines skip the block, no warnings.

Fixes: jgm/pandoc#11524